### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,8 @@ indent_size = 2
 
 # Dotnet code style settings:
 [*.{cs,vb}]
+tab_width = 4
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 # Avoid "this." and "Me." if not necessary
@@ -56,6 +58,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:error
 
 # IDE0040: Add accessibility modifiers
 dotnet_diagnostic.IDE0040.severity = error
+
+# IDE1100: Error reading content of source file 'Project.TargetFrameworkMoniker' (i.e. from ThisAssembly)
+dotnet_diagnostic.IDE1100.severity = none
 
 [*.cs]
 # Top-level files are definitely OK

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,94 @@
+# .NET Repository
+
+**Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
+
+## Working Effectively
+
+### Essential Build Commands
+- **Restore dependencies**: `dotnet restore`
+
+- **Build the entire solution**: `dotnet build`
+
+- **Run tests**: `dnx --yes retest`
+  - Runs all unit tests across the solution
+  - If tests fail due to Azure Storage, run the following commands and retry: `npm install azurite` and `npx azurite &`
+
+### Build Validation and CI Requirements
+- **Always run before committing**: 
+  * `dnx --yes retest`
+  * `dotnet format whitespace -v:diag --exclude ~/.nuget`
+  * `dotnet format style -v:diag --exclude ~/.nuget`
+
+### Project Structure and Navigation
+
+| Directory | Description |
+|-----------|-------------|
+| `src/` | Contains the repo source code. |
+| `bin/` | Contains built packages (if any) |
+
+### Code Style and Formatting
+
+#### EditorConfig Rules
+The repository uses `.editorconfig` at the repo root for consistent code style.
+
+- **Indentation**: 4 spaces for C# files, 2 spaces for XML/YAML/JSON
+- **Line endings**: LF (Unix-style)
+- **Sort using directives**: System.* namespaces first (`dotnet_sort_system_directives_first = true`)
+- **Type references**: Prefer language keywords over framework type names (`int` vs `Int32`)
+- **Modern C# features**: Use object/collection initializers, coalesce expressions when possible, use var when the type is apparent from the right-hand side of the assignment
+- **Visibility modifiers**: only explicitly specify visibility when different from the default (e.g. `public` for classes, no `internal` for classes or `private` for fields, etc.)
+
+#### Formatting Validation
+- CI enforces formatting with `dotnet format whitespace` and `dotnet format style`
+- Run locally: `dotnet format whitespace --verify-no-changes -v:diag --exclude ~/.nuget`
+- Fix formatting: `dotnet format` (without `--verify-no-changes`)
+
+### Testing Practices
+
+#### Test Framework
+- **xUnit** for all unit and integration tests
+- **Moq** for mocking dependencies
+- Located in `src/*.Tests/`
+
+#### Test Attributes
+Custom xUnit attributes are sometimes used for conditional test execution:
+- `[SecretsFact("XAI_API_KEY")]` - Skips test if required secrets are missing from user secrets or environment variables
+- `[LocalFact("SECRET")]` - Runs only locally (skips in CI), requires specified secrets
+- `[CIFact]` - Runs only in CI environment
+
+### Dependency Management
+
+#### Adding Dependencies
+- Add to appropriate `.csproj` file
+- Run `dotnet restore` to update dependencies
+- Ensure version consistency across projects where applicable
+
+#### CI/CD Pipeline
+- **Build workflow**: `.github/workflows/build.yml` - runs on PR and push to main/rel/feature branches
+- **Publish workflow**: Publishes to Sleet feed when `SLEET_CONNECTION` secret is available
+- **OS matrix**: Configured in `.github/workflows/os-matrix.json` (defaults to ubuntu-latest)
+
+### Special Files and Tools
+
+#### dnx Command
+- **Purpose**: built-in tool for running arbitrary dotnet tools that are published on nuget.org. `--yes` auto-confirms install before run.
+- **Example**: `dnx --yes retest` - runs tests with automatic retry on transient failures (retest being a tool package published at https://www.nuget.org/packages/retest)
+- **In CI**: `dnx --yes retest -- --no-build` (skips build, runs tests only)
+
+#### Directory.Build.rsp
+- MSBuild response file with default build arguments
+- `-nr:false` - disables node reuse
+- `-m:1` - single-threaded build (for stability)
+- `-v:m` - minimal verbosity
+
+#### Code Quality
+- All PRs must pass format validation
+- Tests must pass on all target frameworks
+- Follow existing patterns and conventions in the codebase
+
+## Documenting Work
+
+Project implemention details, design and key decisions should be documented in a top-level AGENTS.md file at the repo root. 
+Keep this file updated whenever you make change significant changes for future reference.
+
+User-facing features and APIs should be documented to highlight (not extensively, as an overview) key project features and capabilities, in the readme.md file at the repo root.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
         - Release
         - Debug
   push:
-    branches: [ main, dev, 'dev/*', 'feature/*', 'rel/*' ]
+    branches: [ main, 'feature/*', 'rel/*' ]
     paths-ignore:
       - changelog.md
       - readme.md
@@ -72,9 +72,8 @@ jobs:
         run: dotnet build -m:1 -bl:build.binlog
 
       - name: 🧪 test
-        run: |
-          dotnet tool update -g dotnet-retest
-          dotnet retest -- --no-build
+        shell: pwsh
+        run: dnx --yes retest -- --no-build
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - 'main'
     paths:
-      - '**.md'    
+      - '**.md'
       - '!changelog.md'
+      - 'osmfeula.txt'
 
 jobs:
   includes:
@@ -31,14 +32,33 @@ jobs:
       - name: +Mᐁ includes
         uses: devlooped/actions-includes@v1
 
+      - name: 📝 OSMF EULA
+        shell: pwsh
+        run: |
+          $file = "osmfeula.txt"
+          $props = "src/Directory.Build.props"
+          if (-not (test-path $file) -or -not (test-path $props)) {
+            exit 0
+          }
+
+          $product = dotnet msbuild $props -getproperty:Product
+          if (-not $product) { 
+            write-error 'To use OSMF EULA, ensure the $(Product) property is set in Directory.props'
+            exit 1
+          }
+          
+          ((get-content -raw $file) -replace '\$product\$',$product).trim() | set-content $file
+
       - name: ✍ pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: '**.md'
+          add-paths: |
+            **.md
+            *.txt
           base: main
           branch: markdown-includes
           delete-branch: true
-          labels: docs
+          labels: dependencies
           author: ${{ env.BOT_AUTHOR }}
           committer: ${{ env.BOT_AUTHOR }}
           commit-message: +Mᐁ includes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,8 @@ jobs:
         run: dotnet build -m:1 -bl:build.binlog
 
       - name: 🧪 test
-        run: |
-          dotnet tool update -g dotnet-retest
-          dotnet retest -- --no-build
+        shell: pwsh
+        run: dnx --yes retest -- --no-build
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,7 +49,11 @@ jobs:
           # if we don't have at least 100 requests left, wait until reset
           if ($rate.remaining -lt 100) {
               $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
-              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              if ($wait -gt 300) {
+                  echo "Rate limit remaining is $($rate.remaining), reset in $wait seconds (more than 5'). Aborting."
+                  exit 1
+              }
+              echo "Rate limit remaining is $($rate.remaining), waiting $wait seconds to reset"
               sleep $wait
               $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
               echo "Rate limit has reset to $($rate.remaining) requests"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ BenchmarkDotNet.Artifacts
 .genaiscript
 .idea
 local.settings.json
+.env
+*.local
 
 *.suo
 *.sdf

--- a/.netconfig
+++ b/.netconfig
@@ -17,9 +17,9 @@
 	skip
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	sha = e81ab754b366d52d92bd69b24bef1d5b1c610634
+	sha = a62c45934ac2952f2f5d54d8aea4a7ebc1babaff
 
-	etag = 7298c6450967975a8782b5c74f3071e1910fc59686e48f9c9d5cd7c68213cf59
+	etag = b5e919b472a52d4b522f86494f0f2c0ba74a6d9601454e20e4cbaf744317ff62
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
@@ -47,9 +47,9 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = 56c2b8532c2f86235a0f5bd00ba6eba126f199cf
+	sha = 5da103cfbc1c4f9b5f59cfa698d2afbd744a7525
 
-	etag = bf99c19427f4372ecfe38ec56aa8c411058684fb717da5661f17ac00388b3602
+	etag = 851af098748f7cfa5bc3cfd4cc404a6de930532b59ceb2b3b535282c41226f3a
 	weak
 [file ".github/workflows/changelog.config"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.config
@@ -77,27 +77,27 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 85829f2510f335f4a411867f3dbaaa116c3ab3de
+	sha = 06628725a6303bb8c4cf3076a384fc982a91bc0b
 
-	etag = 086f6b6316cc6ea7089c0dcc6980be519e6ed6e6201e65042ef41b82634ec0ee
+	etag = 478f91d4126230e57cc601382da1ba23f9daa054645b4af89800d8dd862e64fd
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = 56c2b8532c2f86235a0f5bd00ba6eba126f199cf
+	sha = 7f5f9ee9f362f7e8f951d618f8f799033550e687
 
-	etag = 2ef43521627aa3a91dd55bdc2856ec0c6a93b42485d4fe9d6b181f9ee42c8e18
+	etag = c60411d1aa4e98e7f69e2d34cbccb8eb7e387ec11f6f8e78ee8d8b92122d7025
 	weak
 [file ".github/workflows/triage.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/triage.yml
-	sha = 33000c0c4ab4eb4e0e142fa54515b811a189d55c
+	sha = 61a602fc61eedbdae235f01e93657a6219ac2427
 
-	etag = 013a47739e348f06891f37c45164478cca149854e6cd5c5158e6f073f852b61a
+	etag = 152cd3a559c08da14d1da12a5262ba1d2e0ed6bed6d2eabf5bd209b0c35d8a75
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = e0be248fff1d39133345283b8227372b36574b75
+	sha = a225b7a9f609f26bcc24e0d84f663387be251a7d
 
-	etag = c449ec6f76803e1891357ca2b8b4fcb5b2e5deeff8311622fd92ca9fbf1e6575
+	etag = 20a8b49d57024abbd85aac5b0020c30e5eb68e0384b2761e93727c8780c4a991
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -125,15 +125,15 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 81d972fd0760c244d134dae7f4b17d6c43cb004a
+	sha = dd13ed3334135c30dcb1e3b2295dc7622de298d9
 
-	etag = 1368697c1521e465a1dea88b93787b1c7def441c37d62afc903fb8d07179e4f6
+	etag = bd05f9f240823c0ac79ddfefe654061550c36f82dd94fa513b82900e92686a5f
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = a8b208093599263b7f2d1fe3854634c588ea5199
+	sha = 083a37bd9307ec820bac6ee3c7384083151d36d8
 
-	etag = 19087699f05396205e6b050d999a43b175bd242f6e8fac86f6df936310178b03
+	etag = 907682e5632a2ba430357e6e042a4ca33cb8c94a3a215d3091aa03f5958a4877
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
@@ -143,7 +143,18 @@
 	weak
 [file "src/Grok/Extensions/Sixel.cs"]
 	url = https://github.com/devlooped/catbag/blob/main/SixLabors/ImageSharp/Sixel.cs
-	sha = 46a33c3c89b7a81b5d58899a1fabbc6ad23c4cc0
+	sha = 676dcef14a36b89cbc40b93c70b44e1123f38b4f
 
-	etag = 51aba06224650c9317d075c87335c63e9e753c2c829903deb92df860bcffbbaa
+	etag = e1474f427057d30179478702f7d37ee74ef7e194705707dfa10f29790e5846cb
+	weak
+[file "readme.tmp.md"]
+	url = https://github.com/devlooped/oss/blob/main/readme.tmp.md
+	skip
+[file "oss.cs"]
+	url = https://github.com/devlooped/oss/blob/main/oss.cs
+	skip
+[file ".github/copilot-instructions.md"]
+	url = https://github.com/devlooped/oss/blob/main/.github/copilot-instructions.md
+	sha = e616d89d9537c4b8ccf1c20dd277ab82104167c4
+	etag = 6ee650d118a57494d3545d54718ccaa5257b09d54504e9c21514fe596edd9678
 	weak

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+<Project TreatAsLocalProperty="VersionPrefix">
   <!-- To extend/change the defaults, create a Directory.props alongside this file -->
 
   <PropertyGroup Label="CI" Condition="'$(CI)' == ''">
@@ -20,6 +20,7 @@
 
   <PropertyGroup Label="NuGet">
     <Authors>Daniel Cazzulino</Authors>
+    <Company>Devlooped</Company>
     <Copyright>Copyright (C) Daniel Cazzulino and Contributors. All rights reserved.</Copyright>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -42,6 +43,10 @@
 
     <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
     <GeneratePathProperty>true</GeneratePathProperty>
+    <!-- Avoid warnings for test projects when we run dotnet pack on the whole solution. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <!-- See https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#prunepackagereference-specification -->
+    <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -133,6 +138,15 @@
     <VersionSuffix Condition="!$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</VersionSuffix>
     <!-- Special case for tags, the label is actually the version. Backs compat since passed-in value overrides MSBuild-set one -->
     <Version Condition="$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</Version>
+
+    <!-- In order for latest from main/master to always be greatest when using -prerelease switch on install/run, 
+         we change the scheme as follows:
+         - main/master remain as today: VersionPrefix: 42.42.${{ github.run_number }}  (from yaml)
+         - others: VersionPrefix: 42.42.0-[label].${{ github.run_number }}
+    -->
+    <IsMaster Condition="$(VersionLabel.Contains('refs/heads/main')) or $(VersionLabel.Contains('refs/heads/master'))">true</IsMaster>
+    <VersionPrefix Condition="'$(IsMaster)' != 'true'">42.42.0</VersionPrefix>
+    <VersionSuffix Condition="'$(IsMaster)' != 'true'">$(VersionSuffix).$(GITHUB_RUN_NUMBER)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">
@@ -150,6 +164,10 @@
     <Using Include="System.ArgumentException" Static="true" />
     <Using Include="System.ArgumentOutOfRangeException" Static="true" />
     <Using Include="System.ArgumentNullException" Static="true" />
+  </ItemGroup>
+
+  <ItemGroup Label="OSMF" Condition="Exists('$(MSBuildThisFileDirectory)..\osmfeula.txt')">
+    <Content Include="$(MSBuildThisFileDirectory)..\osmfeula.txt" Link="osmfeula.txt" Pack="true" PackagePath="OSMFEULA.txt" />
   </ItemGroup>
 
   <Import Project="Directory.props" Condition="Exists('Directory.props')"/>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -165,21 +165,34 @@
 
     <PropertyGroup>
       <RepositoryRoot>@(_GitSourceRoot)</RepositoryRoot>
+      <!-- Only change if it wasn't just the default from Microsoft.NET.DefaultAssemblyInfo.targets -->
+      <ProductFromUrl Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">$([System.IO.Path]::GetFileNameWithoutExtension($(PrivateRepositoryUrl)))</ProductFromUrl>
+      <Product Condition="'$(Product)' == '$(AssemblyName)' and '$(ProductFromUrl)' != ''">$(ProductFromUrl)</Product>
     </PropertyGroup>
 
   </Target>
 
   <Target Name="UpdatePackageMetadata"
           BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GetAssemblyVersion;GetPackageMetadata;GenerateNuspec;Pack"
-          DependsOnTargets="EnsureProjectInformation"
+          DependsOnTargets="EnsureProjectInformation;UpdatePackageLicense"
           Condition="'$(SourceControlInformationFeatureSupported)' == 'true' And
                      '$(IsPackable)' == 'true'">
     <PropertyGroup>
-      <PackageProjectUrl Condition="'$(PackageProjectUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(RepositoryUrl)</PackageProjectUrl>
+      <PackageProjectUrl Condition="'$(PackageProjectUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(RepositoryUrl.Replace('.git', ''))</PackageProjectUrl>
       <PackageDescription>$(Description)</PackageDescription>
-      <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl)/blob/main/changelog.md</PackageReleaseNotes>
+      <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl.Replace('.git', ''))/blob/main/changelog.md</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
+
+  <Target Name="UpdatePackageLicense">
+    <!-- If project has a None/Content item with PackagePath=OSMFEULA.txt -->
+    <PropertyGroup Condition="@(None -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != '' or @(Content -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != ''">
+      <PackageLicenseExpression></PackageLicenseExpression>
+      <PackageLicenseFile>OSMFEULA.txt</PackageLicenseFile>
+      <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    </PropertyGroup>
+  </Target>
+
 
   <!-- Import before UsingTask because first to declare tasks wins -->
   <Import Project="Directory.targets" Condition="Exists('Directory.targets')"/>

--- a/src/Grok/Extensions/Sixel.cs
+++ b/src/Grok/Extensions/Sixel.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
@@ -39,16 +40,11 @@ namespace SixLabors.ImageSharp;
 /// Provides methods for converting images to Sixel format, which is a bitmap graphics format used
 /// to render images directly in the terminal.
 /// </summary>
-public static class Sixel
+static partial class Sixel
 {
-    const byte Cutoff = 127;
-    const string Prelude = "\x1BP7;1;q";
-    const string Epilogue = "\x1B\\";
-
     /// <summary>
     /// Detects if the terminal supports sixel graphics.
     /// </summary>
-    /// <returns></returns>
     public static bool DetectSupport()
     {
         // Use console capabilities to check for sixel support
@@ -71,8 +67,18 @@ public static class Sixel
     /// on the image.
     /// </summary>
     /// <param name="image"></param>
-    /// <returns></returns>
     public static string FromImage(Image<Rgba32> image) => image.ToSixel();
+}
+
+/// <summary>
+/// Provides extension methods for working with Sixel.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+static partial class SixelExtensions 
+{
+    const byte Cutoff = 127;
+    const string Prelude = "\x1BP7;1;q";
+    const string Epilogue = "\x1B\\";
 
     extension(Image<Rgba32> image)
     {


### PR DESCRIPTION
# devlooped/oss

- Enhance documentation instructions for project work https://github.com/devlooped/oss/commit/e616d89
- Add Company MSBuild property by default https://github.com/devlooped/oss/commit/c509be4
- Disable warnings for non-packable test projects https://github.com/devlooped/oss/commit/95b338b
- Update versioning scheme in Directory.Build.props https://github.com/devlooped/oss/commit/f2400ef
- Enable package pruning in Directory.Build.props https://github.com/devlooped/oss/commit/0ff8b7b
- Enhance include workflow with OSMF EULA support https://github.com/devlooped/oss/commit/f2050db
- Trim whitespace in file content replacement https://github.com/devlooped/oss/commit/e53557f
- Fix path pattern for markdown files in workflow https://github.com/devlooped/oss/commit/6a6de05
- Fix error message quotes in includes.yml https://github.com/devlooped/oss/commit/26e8cb7
- If the OSMF eula is present, switch to its license file https://github.com/devlooped/oss/commit/4b84c54
- Change file type from None to Content for osmfeula.txt https://github.com/devlooped/oss/commit/fd03672
- Add Pack attribute to OSMFEULA content item https://github.com/devlooped/oss/commit/dd13ed3
- Change label from 'docs' to 'dependencies' https://github.com/devlooped/oss/commit/2d1fb4e
- Avoid failure on PR creation if osmfeula.txt doesn't exist in repo https://github.com/devlooped/oss/commit/8ff5178
- Update create-pull-request action to version 8 https://github.com/devlooped/oss/commit/0662872
- Switch to dnx retest shorthand https://github.com/devlooped/oss/commit/fddfd89
- Ensure quiet confirmation of tool download/install https://github.com/devlooped/oss/commit/e11b002
- Ensure dnx run succeeds even on Windows https://github.com/devlooped/oss/commit/7f5f9ee
- Cap rate limit wait at 5 minutes, abort if longer https://github.com/devlooped/oss/commit/61a602f
- Improve default Product metadata, remove .git from user-facing URLs https://github.com/devlooped/oss/commit/4339749
- Consider either None or Content for OSMF license patching https://github.com/devlooped/oss/commit/083a37b
- Ignore .env files recursively https://github.com/devlooped/oss/commit/3776526
- Set severity of IDE1100 to none https://github.com/devlooped/oss/commit/1ed9afe
- Set explicit tab size and eol for code files https://github.com/devlooped/oss/commit/5dba0d0
- Revert EOL change in editorconfig for C# files https://github.com/devlooped/oss/commit/2d0e5a5
- Revert indent size for project files https://github.com/devlooped/oss/commit/a62c459
- Ignore *.local recursively https://github.com/devlooped/oss/commit/a225b7a
- Update branches for push event in build.yml https://github.com/devlooped/oss/commit/5da103c

# devlooped/catbag

- Fix compilation error in Sixel support, update ImageSharp https://github.com/devlooped/catbag/commit/676dcef